### PR TITLE
Make quickinstall functional on postgres

### DIFF
--- a/modules/qi_create.php
+++ b/modules/qi_create.php
@@ -209,6 +209,16 @@ class qi_create
 			{
 				$db_check = $db->sql_select_db($quickinstall_path . 'cache/' . $qi_config['db_prefix'] . $dbname);
 			}
+			else if ($dbms == 'postgres')
+			{
+				global $sql_db, $dbhost, $dbuser, $dbpasswd, $dbport;
+				$error_collector = new phpbb_error_collector();
+				$error_collector->install();
+				$db_check_conn = new $sql_db();
+				$db_check_conn->sql_connect($dbhost, $dbuser, $dbpasswd, $qi_config['db_prefix'] . $dbname, $dbport, false, false);
+				$error_collector->uninstall();
+				$db_check = count($error_collector->errors) == 0;
+			}
 			else
 			{
 				$db_check = $db->sql_select_db($qi_config['db_prefix'] . $dbname);
@@ -224,6 +234,13 @@ class qi_create
 		{
 			$db->sql_query('CREATE DATABASE ' . $quickinstall_path . 'cache/' . $qi_config['db_prefix'] . $dbname);
 			$db->sql_select_db($quickinstall_path . 'cache/' . $qi_config['db_prefix'] . $dbname);
+		}
+		else if ($dbms == 'postgres')
+		{
+			$db->sql_query('CREATE DATABASE ' . $qi_config['db_prefix'] . $dbname);
+			$db = new $sql_db();
+			$db->sql_connect($dbhost, $dbuser, $dbpasswd, $qi_config['db_prefix'] . $dbname, $dbport, false, false);
+			$db->sql_return_on_error(true);
 		}
 		else
 		{


### PR DESCRIPTION
This unbreaks postgresql support in quickinstall.

This pull request appears to be independent from my other pull request, however in practice I use this code on top of the unwriteable config commits.
