### PR TITLE
Unbreak QI with postgres if board is populated by updating sequence values for topics and posts

### DIFF
--- a/includes/db/mssql.php
+++ b/includes/db/mssql.php
@@ -50,6 +50,14 @@ class dbal_mssql_qi extends dbal_mssql
 	{
 		return @mssql_select_db($dbname, $this->db_connect_id);
 	}
+
+	/**
+	 * Updates value of a sequence.
+	 * Does nothing in this dbal.
+	 */
+	public function update_sequence($sequence_name, $value)
+	{
+	}
 }
 
 ?>

--- a/includes/db/mysql.php
+++ b/includes/db/mysql.php
@@ -65,6 +65,14 @@ class dbal_mysql_qi extends dbal_mysql
 	{
 		return @mysql_select_db($dbname, $this->db_connect_id);
 	}
+
+	/**
+	 * Updates value of a sequence.
+	 * Does nothing in this dbal.
+	 */
+	public function update_sequence($sequence_name, $value)
+	{
+	}
 }
 
 ?>

--- a/includes/db/mysqli.php
+++ b/includes/db/mysqli.php
@@ -54,6 +54,14 @@ class dbal_mysqli_qi extends dbal_mysqli
 	{
 		return @mysqli_select_db($this->db_connect_id, $dbname);
 	}
+
+	/**
+	 * Updates value of a sequence.
+	 * Does nothing in this dbal.
+	 */
+	public function update_sequence($sequence_name, $value)
+	{
+	}
 }
 
 ?>

--- a/includes/db/postgres.php
+++ b/includes/db/postgres.php
@@ -31,4 +31,13 @@ class dbal_postgres_qi extends dbal_postgres
 		}
 		return parent::sql_connect($dbhost, $dbuser, $dbpass, $dbname, $dbport, $persistency, $new_link);
 	}
+
+	/**
+	 * Updates value of a sequence.
+	 */
+	public function update_sequence($sequence_name, $value)
+	{
+	      $result = $this->sql_query("select setval('$sequence_name', '$value')");
+	      $this->sql_freeresult($result);
+	}
 }

--- a/includes/db/sqlite.php
+++ b/includes/db/sqlite.php
@@ -107,6 +107,14 @@ class dbal_sqlite_qi extends dbal_sqlite
 
 		return $this->db_connect_id;
 	}
+
+	/**
+	 * Updates value of a sequence.
+	 * Does nothing in this dbal.
+	 */
+	public function update_sequence($sequence_name, $value)
+	{
+	}
 }
 
 ?>

--- a/includes/functions_populate.php
+++ b/includes/functions_populate.php
@@ -407,6 +407,9 @@ class populate
 		// phpBB installs the forum with one topic and one post.
 		set_config('num_topics', $topic_cnt + 1);
 		set_config('num_posts', $post_cnt + 1);
+
+		$db->update_sequence(TOPICS_TABLE . '_seq', $topic_cnt + 1);
+		$db->update_sequence(POSTS_TABLE . '_seq', $post_cnt + 1);
 	}
 
 	/**


### PR DESCRIPTION
On postgres sequences have to be manually updated if data is inserted
into tables with explicit ids.

Add functions for updating sequence values to all supported databases;
implement postgres version, all others do nothing at this time.

http://www.phpbb.com/bugs/modteamtools/62875
