### PR TITLE
No need to globalize db variables as they already exist (postgres)

### DIFF
--- a/modules/qi_create.php
+++ b/modules/qi_create.php
@@ -189,6 +189,7 @@ class qi_create
 			}
 			else if ($dbms == 'postgres')
 			{
+				global $sql_db;
 				$error_collector = new phpbb_error_collector();
 				$error_collector->install();
 				$db_check_conn = new $sql_db();
@@ -219,6 +220,7 @@ class qi_create
 		}
 		else if ($dbms == 'postgres')
 		{
+			global $sql_db;
 			$db->sql_query('CREATE DATABASE ' . $db_prefix . $dbname);
 			$db = new $sql_db();
 			$db->sql_connect($dbhost, $dbuser, $dbpasswd, $db_prefix . $dbname, $dbport, false, false);


### PR DESCRIPTION
This fixes the attempt to connect as the user running the code.

However then I receive the following fatal:

<pre>
( ! ) Fatal error: Class name must be a valid object or a string in /var/www/qi/modules/qi_create.php on line 223
Call Stack
#   Time    Memory  Function    Location
1   0.0004  267256  {main}( )   ../index.php:0
2   0.0313  3081440 module_handler->load( ) ../index.php:155
3   0.0328  3220408 qi_create->__construct( )   ../functions_module.php:55
</pre>


Not sure what to do with this one.
