### PR TITLE
Fix footer displaying in "qi_functions.php" when "gen_error_msg()" is called

### DIFF
--- a/includes/qi_functions.php
+++ b/includes/qi_functions.php
@@ -225,8 +225,8 @@ echo<<<ERROR_PAGE
 			</div>
 
 			<div id="page-footer">
-				<a href="https://www.phpbb.com/customise/db/official_tool/phpbb3_quickinstall/">phpBB QuickInstall</a> $qi_version for phpBB 3.0 and 3.1 &copy; <a href="https://www.phpbb.com/">phpBB Limited</a><br />';
-				Powered by phpBB&reg; Forum Software &copy; <a href="https://www.phpbb.com/">phpBB Limited</a>';
+				<a href="https://www.phpbb.com/customise/db/official_tool/phpbb3_quickinstall/">phpBB QuickInstall</a> $qi_version for phpBB 3.0 and 3.1 &copy; <a href="https://www.phpbb.com/">phpBB Limited</a><br />
+				Powered by phpBB&reg; Forum Software &copy; <a href="https://www.phpbb.com/">phpBB Limited</a>
 			</div>
 		</div>
 	</body>


### PR DESCRIPTION
Due a bad copy/paste in a previous PR, the `';` are visible in the footer when `gen_error_msg()` is called.
