### PR TITLE
Fix for UTF-8 characters are not supported in $error_msg

### DIFF
--- a/modules/qi_main.php
+++ b/modules/qi_main.php
@@ -53,7 +53,7 @@ class qi_main
 			'DEFAULT_STYLE'		=> $settings->get_config('default_style', ''),
 
 			'S_ERROR'		=> $settings->get_config('error', 0),
-			'ERROR_TITLE'	=> $settings->get_config('error_title', '',true),
+			'ERROR_TITLE'	=> $settings->get_config('error_title', '', true),
 
 			'S_AUTOMOD'		=> $settings->get_config('automod', 0),
 			'S_DELETE_FILES'=> $settings->get_config('delete_files', 0),

--- a/modules/qi_main.php
+++ b/modules/qi_main.php
@@ -53,7 +53,7 @@ class qi_main
 			'DEFAULT_STYLE'		=> $settings->get_config('default_style', ''),
 
 			'S_ERROR'		=> $settings->get_config('error', 0),
-			'ERROR_TITLE'	=> $settings->get_config('error_title', ''),
+			'ERROR_TITLE'	=> $settings->get_config('error_title', '',true),
 
 			'S_AUTOMOD'		=> $settings->get_config('automod', 0),
 			'S_DELETE_FILES'=> $settings->get_config('delete_files', 0),


### PR DESCRIPTION
Hi @marc1706  & @tumba25,

this is a missing fix submitted by @Skouat, here: https://www.phpbb.com/customise/db/official_tool/phpbb3_quickinstall/support/topic/133911?p=416141#p416141.