### PR TITLE
Recalculate posts and user times

### DIFF
--- a/includes/functions_populate.php
+++ b/includes/functions_populate.php
@@ -917,6 +917,8 @@ class populate
 		// update board's start date
 		set_config('board_startdate', $this->start_time);
 
+		$db->sql_transaction('begin');
+
 		// update the default first forum and category
 		$sql = 'UPDATE ' . FORUMS_TABLE . '
 			SET forum_last_post_time = ' . (int) $this->start_time . '
@@ -941,5 +943,7 @@ class populate
 			SET user_regdate =  ' . (int) $this->start_time . '
 			WHERE ' . $db->sql_in_set('user_id', array(1, 2));
 		$db->sql_query($sql);
+
+		$db->sql_transaction('commit');
 	}
 }

--- a/includes/functions_populate.php
+++ b/includes/functions_populate.php
@@ -888,7 +888,8 @@ class populate
 	{
 		global $db;
 		$user_row = array();
-		$sql = 'SELECT user_id, username, user_posts, user_lastpost_time, user_lastmark FROM ' . USERS_TABLE . '
+		$sql = 'SELECT user_id, username, user_posts, user_lastpost_time, user_lastmark 
+			FROM ' . USERS_TABLE . '
 			WHERE user_id = ' . (int) $id;
 		$result = $db->sql_query_limit($sql, 1);
 		while ($row = $db->sql_fetchrow($result))


### PR DESCRIPTION
Fixes #63 

There are problems with the way QI generates users and posts. It basically goes back in time, generating users and posts with times leading up to the current time.

That means the users and posts all have times that pre-date the board start date (and the admin).

It also does not consider the user dates vs. the post dates, meaning posts are created with post dates that can pre-date the join date of the user who supposedly created the post.

~~This inconsistency has been addressed here by instead future dating all posts and users. So now, users are created starting from the board creation date and moving forward, separated by a second each. And then all posts are created after the last user join date, separated by a second each.~~

~~This should make the dates more realistic, but does have one drawback which is the posts and users will have times from the future, time that hasn't passed yet, at least for the first few minutes (or hours) of the board's life.~~