### PR TITLE
Always populate bbcode_uid

### DIFF
--- a/includes/functions_populate.php
+++ b/includes/functions_populate.php
@@ -386,7 +386,7 @@ class populate
 						'post_text'			=> $post_text,
 						'post_checksum'		=> md5($post_text),
 						'bbcode_bitfield'	=> $bbcode_bitfield,
-						'bbcode_uid'		=> $bbcode_uid,
+						'bbcode_uid'		=> 'a',
 					);
 
 					if (defined('PHPBB_31'))


### PR DESCRIPTION
Search won't remove BBcodes unless `bbcode_uid` is populated. The reason why `generate_text_for_storage()` won't generate it is unknown to me but it is never ever used really so instead of true fix I opted for an easy solution - use `a` for every post.

Fixes #107.