### PR TITLE
Disable mysqli error reporting since PHP 8.1 changed the default.

### DIFF
--- a/includes/db/mysqli.php
+++ b/includes/db/mysqli.php
@@ -39,6 +39,13 @@ class dbal_mysqli_qi extends \phpbb\db\driver\mysqli
 
 		if ($this->db_connect_id)
 		{
+			/*
+			 * As of PHP 8.1 MySQLi default error mode is set to MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT
+			 * See https://wiki.php.net/rfc/mysqli_default_errmode
+			 * Since phpBB implements own SQL errors handling, explicitly set it back to MYSQLI_REPORT_OFF
+			 */
+			mysqli_report(MYSQLI_REPORT_OFF);
+
 			@mysqli_query($this->db_connect_id, "SET NAMES 'utf8'");
 			return $this->db_connect_id;
 		}


### PR DESCRIPTION
This prevents an uncaught mysqli_sql_exception during schema creation when using the mysqli driver on PHP 8.1 or newer.